### PR TITLE
bump up node js to version 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ inputs:
     description: 'comma delimited kernel module names to install for kepler CI, e.g. rapl,intel_rapl_msr'
     required: false
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
ref https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/ github announcement bump up nodejs version to 20 